### PR TITLE
No-op commit to trigger GHA PR workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
           ls /usr/share/miniconda/bin/
           ls /usr/share/miniconda/
            
+      # I want to see if this step still works in Mar 2026
       - name: Create Conda Environment
         run: |
           /usr/share/miniconda/bin/mamba create -n marine_environment python=3.10 -y


### PR DESCRIPTION
Related to issue #74, I want to run the GHA PR workflow automation and see if it still passes; in particular I want to see whether the `mamba install` step still runs cleanly or has the same issues reported in that issue.